### PR TITLE
Added a listener for using an offset for fixed navbars

### DIFF
--- a/src/js/modules/scrollspy.js
+++ b/src/js/modules/scrollspy.js
@@ -13,6 +13,8 @@ function ScrollSpy (wrapper, opt) {
 
   this.callback = opt.callback;
 
+  this.fixedNavbarOffset = opt.fixedNavbarOffset;
+
   this.init();
 }
 
@@ -109,7 +111,7 @@ ScrollSpy.prototype.isInView = function (el) {
     scrollBottom = scrollTop + winH,
     rect = el.getBoundingClientRect(),
     elTop = rect.top + scrollTop,
-    elBottom = elTop + el.offsetHeight;
+    elBottom = elTop + el.offsetHeight - this.fixedNavbarOffset;
 
   return (elTop < scrollBottom) && (elBottom > scrollTop);
 };


### PR DESCRIPTION
# Reason for modification
We've added an offset variable to use if you have a fixed navbar. Otherwise the active indicator responds the page top which is _underneath_ the fixed navbar.

# How to use / Code example
You can use `fixedNavbarOffset` to indicate an amount of pixels calculated from the top.

```
var spy = new ScrollSpy('#js-scrollspy', {
    nav: '.js-scrollspy-nav > a',
    className: 'is-inview',
    fixedNavbarOffset: 170,
    callback: function () {
      $(".name-navigation a").blur();
    }
  });
```